### PR TITLE
[feat]사이드바 레이아웃

### DIFF
--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -5,18 +5,29 @@ type ChildrenProps = {
   children: React.ReactNode
 }
 
+const SIDE_BAR_WIDTH = '252px'
+
 const Layout = ({ children }: ChildrenProps) => {
   return (
-    <MainLayout>
-      <SideBar />
-      {children}
+    <MainLayout padding={SIDE_BAR_WIDTH}>
+      <SideBar width={SIDE_BAR_WIDTH} />
+      <Contents>{children}</Contents>
     </MainLayout>
   )
 }
 
 export default Layout
 
-const MainLayout = styled.div`
+const MainLayout = styled.div<{ padding: string }>`
   display: flex;
   width: 100%;
+  height: 1024px;
+  padding-left: ${({ padding }) => padding};
+  background-color: ${({ theme }) => theme.backGround};
+`
+
+const Contents = styled.section`
+  width: 100%;
+  height: 100%;
+  padding: 20px 0 20px 20px;
 `

--- a/components/Logo.tsx
+++ b/components/Logo.tsx
@@ -1,0 +1,30 @@
+import Image from 'next/image'
+import styled from 'styled-components'
+
+const Logo = () => {
+  return (
+    <LogoMenu>
+      <Image
+        src={'/images/img_logo01.svg'}
+        width={24}
+        height={24}
+        alt="로고이미지"
+      />
+      <Title>DBDLAB Corp.</Title>
+    </LogoMenu>
+  )
+}
+
+export default Logo
+
+const LogoMenu = styled.div`
+  display: flex;
+  align-items: center;
+  width: 100%;
+  height: 40px;
+`
+
+const Title = styled.p`
+  font-weight: bold;
+  margin-left: 5px;
+`

--- a/components/Menu.tsx
+++ b/components/Menu.tsx
@@ -1,0 +1,30 @@
+import styled from 'styled-components'
+import MenuButton from './MenuButton'
+
+const SIDE_MENU_LIST = [
+  { id: 1, name: 'Dashboard', image: '/images/icon_dashboard01.svg' },
+  { id: 2, name: 'Research', image: '/images/icon_research01.svg' },
+  { id: 3, name: 'Members', image: '/images/icon_members01.svg' },
+  { id: 4, name: 'Insight', image: '/images/icon_insight01.svg' },
+  { id: 5, name: 'Calendar', image: '/images/icon_calendar01.svg' },
+]
+
+const Menu = () => {
+  return (
+    <MenuWrapper>
+      {SIDE_MENU_LIST.map(sideMenu => (
+        <MenuButton key={sideMenu.id} sideMenu={sideMenu} />
+      ))}
+    </MenuWrapper>
+  )
+}
+
+export default Menu
+
+const MenuWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  margin-top: 56px;
+  height: 328px;
+`

--- a/components/MenuButton.tsx
+++ b/components/MenuButton.tsx
@@ -1,0 +1,34 @@
+import styled from 'styled-components'
+import Image from 'next/image'
+
+type menuDataProps = {
+  sideMenu: {
+    id: number
+    name: string
+    image: string
+  }
+}
+
+const MenuButton = ({ sideMenu }: menuDataProps) => {
+  const { name, image } = sideMenu
+
+  return (
+    <SideMenuButton>
+      <Image src={image} width={16} height={16} alt={`${name}이미지`} />
+      <MenuName>{name}</MenuName>
+    </SideMenuButton>
+  )
+}
+
+export default MenuButton
+
+const SideMenuButton = styled.div`
+  display: flex;
+  align-items: center;
+  width: 100%;
+  height: 40px;
+`
+
+const MenuName = styled.p`
+  margin-left: 8px;
+`

--- a/components/SideBar.tsx
+++ b/components/SideBar.tsx
@@ -1,5 +1,26 @@
-const SideBar = () => {
-  return <div>사이드바</div>
+import styled from 'styled-components'
+import Logo from './Logo'
+import Menu from './Menu'
+
+type sideProps = {
+  width: string
+}
+
+const SideBar = ({ width }: sideProps) => {
+  return (
+    <SideBarContainer width={width}>
+      <Logo />
+      <Menu />
+    </SideBarContainer>
+  )
 }
 
 export default SideBar
+
+const SideBarContainer = styled.div<{ width: string }>`
+  position: fixed;
+  left: 0;
+  width: ${({ width }) => width};
+  height: 100%;
+  padding: 48px 0 0 48px;
+`

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,7 +1,9 @@
 import type { AppProps } from 'next/app'
 import Head from 'next/head'
 import GlobalStyle from '../styles/GlobalStyle'
+import { ThemeProvider } from 'styled-components'
 import Layout from '../components/Layout'
+import theme from '../styles/Theme'
 
 function MyApp({ Component, pageProps }: AppProps) {
   return (
@@ -11,9 +13,11 @@ function MyApp({ Component, pageProps }: AppProps) {
         <title>DBD랩 사전과제</title>
       </Head>
       <GlobalStyle />
-      <Layout>
-        <Component {...pageProps} />
-      </Layout>
+      <ThemeProvider theme={theme}>
+        <Layout>
+          <Component {...pageProps} />
+        </Layout>
+      </ThemeProvider>
     </>
   )
 }

--- a/pages/calendar.tsx
+++ b/pages/calendar.tsx
@@ -1,5 +1,10 @@
+import { Main } from '.'
+import styled from 'styled-components'
+
 const calendar = () => {
-  return <div>calendar</div>
+  return <CalendarMain>calendar</CalendarMain>
 }
 
 export default calendar
+
+const CalendarMain = styled(Main)``

--- a/pages/dashboard.tsx
+++ b/pages/dashboard.tsx
@@ -1,4 +1,10 @@
+import { Main } from '.'
+import styled from 'styled-components'
+
 const dashboard = () => {
-  return <div>대쉬보드</div>
+  return <DashboardMain>dashboard</DashboardMain>
 }
+
 export default dashboard
+
+const DashboardMain = styled(Main)``

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -7,4 +7,8 @@ const Index: NextPage = () => {
 
 export default Index
 
-const Main = styled.div``
+export const Main = styled.div`
+  width: 100%;
+  height: 100%;
+  background-color: ${({ theme }) => theme.white};
+`

--- a/pages/insight.tsx
+++ b/pages/insight.tsx
@@ -1,5 +1,10 @@
+import { Main } from '.'
+import styled from 'styled-components'
+
 const insight = () => {
-  return <div>insight</div>
+  return <InsightMain>insight</InsightMain>
 }
 
 export default insight
+
+const InsightMain = styled(Main)``

--- a/pages/members.tsx
+++ b/pages/members.tsx
@@ -1,5 +1,10 @@
+import { Main } from '.'
+import styled from 'styled-components'
+
 const members = () => {
-  return <div>members</div>
+  return <MembersMain>members</MembersMain>
 }
 
 export default members
+
+const MembersMain = styled(Main)``

--- a/pages/research.tsx
+++ b/pages/research.tsx
@@ -1,5 +1,10 @@
+import { Main } from '.'
+import styled from 'styled-components'
+
 const research = () => {
-  return <div>research</div>
+  return <ResearchMain>research</ResearchMain>
 }
 
 export default research
+
+const ResearchMain = styled(Main)``


### PR DESCRIPTION
사이드바 레이아웃 작업완료, theme으로 전역스타일 관리 추가, 
로고와 버튼은 따로 컴포넌트로 분리하여 구현 
추후 메뉴수정을 용이하게 하기위해 메뉴관련 상수데이터를 만들어서 레이아웃 구현
버튼 내 이미지는 이미지 태그를 활용해서 public의 이미지 데이터를 활용하였습니다.

