### PR TITLE
[feat] 버튼 활성화기능 추가

### DIFF
--- a/components/Menu.tsx
+++ b/components/Menu.tsx
@@ -38,5 +38,6 @@ const MenuWrapper = styled.div`
 `
 
 const LinkMenu = styled(Link)`
+  width: fit-content;
   text-decoration: none;
 `

--- a/components/MenuButton.tsx
+++ b/components/MenuButton.tsx
@@ -1,5 +1,7 @@
 import styled from 'styled-components'
 import Image from 'next/image'
+import { useRouter } from 'next/router'
+import { lowerCase } from '../utils/lowercase'
 
 type menuDataProps = {
   sideMenu: {
@@ -11,11 +13,14 @@ type menuDataProps = {
 
 const MenuButton = ({ sideMenu }: menuDataProps) => {
   const { name, image } = sideMenu
+  const router = useRouter()
 
   return (
     <SideMenuButton>
       <Image src={image} width={16} height={16} alt={`${name}이미지`} />
-      <MenuName>{name}</MenuName>
+      <MenuName isActive={router.route.includes(lowerCase(name))}>
+        {name}
+      </MenuName>
     </SideMenuButton>
   )
 }
@@ -25,13 +30,11 @@ export default MenuButton
 const SideMenuButton = styled.div`
   display: flex;
   align-items: center;
-  width: 100%;
   height: 40px;
-  :hover {
-    cursor: pointer;
-  }
 `
 
-const MenuName = styled.p`
+const MenuName = styled.span<{ isActive: boolean }>`
   margin-left: 8px;
+  color: ${({ isActive }) =>
+    isActive ? ({ theme }) => theme.select : ({ theme }) => theme.sideBarFont};
 `

--- a/styles/Theme.ts
+++ b/styles/Theme.ts
@@ -3,7 +3,7 @@ const theme = {
   black: '#000000',
   white: '#FFFFFF',
   backGround: '#F8F8F8',
-  SideBarFont: '#282828',
+  sideBarFont: '#282828',
   border: '#cccccc',
   contentsFont: '#4a4a4a',
 }


### PR DESCRIPTION
현재경로의 router 정보를 이용하여 현재 경로의 이름과 메뉴이름이
동일한 경우에 메뉴폰트의 색상이 파란색으로 변경되도록 하였습니다

메뉴 폰트의 스타일 컴포넌트의 props로 isActive를 넘겨주어 true/false 에따라 css를 다르게 적용하였습니다.

isActive는 router의 route 와 button의 name 을 비교하여 true, false를 판별하도록 하였습니다.