### PR TITLE
[feat]성별관련 차트 레이아웃구현

### DIFF
--- a/components/AgeChart/AgeChart.tsx
+++ b/components/AgeChart/AgeChart.tsx
@@ -1,5 +1,5 @@
 import styled from 'styled-components'
-import AgeGroupExample from './AgeGroup/AgeGroupExample'
+import AgeGroupExample from './AgeGroupExample/AgeGroupExample'
 import DailyStack from './DailyStack/DailyStack'
 import DecideCntLine from './DecideCntLine/DecideCntLine'
 

--- a/components/AgeChart/AgeGroupExample/AgeGroupExample.tsx
+++ b/components/AgeChart/AgeGroupExample/AgeGroupExample.tsx
@@ -1,5 +1,5 @@
 import styled from 'styled-components'
-import AgeGroupItem from './AgeGroupItem'
+import ChartExampleItem from '../../ChartExampleItem'
 
 const AGE_GROUP_DATA = [
   { id: 0, gubun: '0-9', color: 'red' },
@@ -17,7 +17,7 @@ const AgeGroupExample = () => {
   return (
     <AgeGroupWrapper>
       {AGE_GROUP_DATA.map(item => (
-        <AgeGroupItem key={item.id} gubun={item.gubun} color={item.color} />
+        <ChartExampleItem key={item.id} gubun={item.gubun} color={item.color} />
       ))}
     </AgeGroupWrapper>
   )
@@ -27,8 +27,7 @@ export default AgeGroupExample
 
 const AgeGroupWrapper = styled.div`
   display: grid;
-  grid-template-columns: repeat(4, 1fr);
+  grid-template-columns: repeat(5, 1fr);
   align-items: center;
-  justify-items: center;
   margin-top: 20px;
 `

--- a/components/AgeChart/DailyStack/DailyStack.tsx
+++ b/components/AgeChart/DailyStack/DailyStack.tsx
@@ -26,6 +26,7 @@ const DailyStackWrapper = styled.div`
   flex-direction: column;
   justify-content: space-between;
   position: absolute;
+  top: 0;
   left: -15px;
   height: 200px;
 `

--- a/components/ChartExampleItem.tsx
+++ b/components/ChartExampleItem.tsx
@@ -1,32 +1,31 @@
 import styled from 'styled-components'
 
-type AgeGroupItemProps = {
+type ChartExampleItemProps = {
   gubun: string
   color: string
 }
 
-const AgeGroupItem = ({ gubun, color }: AgeGroupItemProps) => {
+const ChartExampleItem = ({ gubun, color }: ChartExampleItemProps) => {
   return (
-    <AgeGroupItemWrapper>
+    <ChartExampleItemWrapper>
       <ChartColor color={color} />
       <Age>{gubun}</Age>
-    </AgeGroupItemWrapper>
+    </ChartExampleItemWrapper>
   )
 }
 
-export default AgeGroupItem
+export default ChartExampleItem
 
-const AgeGroupItemWrapper = styled.div`
+const ChartExampleItemWrapper = styled.div`
   display: flex;
   align-items: center;
-  width: 100px;
   height: 30px;
 `
 
 const ChartColor = styled.div<{ color: string }>`
   width: 16px;
   height: 7px;
-  background-color: ${({ color }) => color};
+  background-color: ${({ theme, color }) => theme[color]};
   margin-right: 5px;
 `
 

--- a/components/ChartLayout.tsx
+++ b/components/ChartLayout.tsx
@@ -38,7 +38,9 @@ const ChartTitle = styled.h1`
 `
 
 const ChartWrapper = styled.article`
+  position: relative;
   display: flex;
+  flex-direction: column;
   justify-content: center;
   align-items: center;
   height: 100%;

--- a/components/GenderChart/GenderChart.tsx
+++ b/components/GenderChart/GenderChart.tsx
@@ -1,0 +1,50 @@
+import styled from 'styled-components'
+import ChartExampleItem from '../ChartExampleItem'
+
+const GenderChart = () => {
+  return (
+    <GenderChartWrapper>
+      <PieChart />
+      <PieChartWhiteSpace />
+      <ChartExampleWrapper>
+        <ChartExampleItem gubun="남자" color="genderMan" />
+        <ChartExampleItem gubun="여자" color="genderWoman" />
+      </ChartExampleWrapper>
+    </GenderChartWrapper>
+  )
+}
+
+export default GenderChart
+
+const GenderChartWrapper = styled.section`
+  position: relative;
+  width: 300px;
+  height: 300px;
+`
+
+const PieChart = styled.div`
+  width: 100%;
+  height: 100%;
+  background: conic-gradient(
+    ${({ theme }) => theme.genderMan} 0% 30%,
+    ${({ theme }) => theme.genderWoman} 30% 100%
+  );
+  border-radius: 50%;
+`
+
+const PieChartWhiteSpace = styled.div`
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 100px;
+  height: 100px;
+  background-color: white;
+  border-radius: 50%;
+  transform: translate(-50%, -50%);
+`
+
+const ChartExampleWrapper = styled.div`
+  display: flex;
+  justify-content: space-evenly;
+  margin-top: 30px;
+`

--- a/pages/dashboard.tsx
+++ b/pages/dashboard.tsx
@@ -2,6 +2,7 @@ import { Main } from '.'
 import styled from 'styled-components'
 import ChartLayout from '../components/ChartLayout'
 import AgeChart from '../components/AgeChart/AgeChart'
+import GenderChart from '../components/GenderChart/GenderChart'
 
 const dashboard = () => {
   return (
@@ -20,7 +21,16 @@ const dashboard = () => {
           />
         </ChartLayout>
         <ChartLayout title="일자별 성별 확진자 수">
-          <Chart />
+          <DateSelector>
+            <Date>11/01</Date>
+            <Date>11/02</Date>
+            <Date>11/03</Date>
+            <Date>11/04</Date>
+            <Date>11/05</Date>
+            <Date>11/06</Date>
+            <Date>11/07</Date>
+          </DateSelector>
+          <GenderChart />
         </ChartLayout>
       </BottomChartWrapper>
     </DashboardMain>
@@ -49,6 +59,15 @@ const UpperChartWrapper = styled.section`
 `
 
 const BottomChartWrapper = styled(UpperChartWrapper)``
+
+const DateSelector = styled.select`
+  position: absolute;
+  top: 10px;
+  right: 50px;
+  width: 80px;
+`
+
+const Date = styled.option``
 
 const DATA = [
   {

--- a/styles/Theme.ts
+++ b/styles/Theme.ts
@@ -2,12 +2,23 @@ const theme = {
   select: '#2878F0',
   black: '#000000',
   white: '#FFFFFF',
+  red: 'red',
+  orange: 'orange',
+  yellow: 'yellow',
+  green: 'green',
+  blue: 'blue',
+  navy: 'navy',
+  violet: 'violet',
+  aqua: 'aqua',
+  grey: 'grey',
   backGround: '#F8F8F8',
   sideBarFont: '#282828',
   border: '#cccccc',
   contentsFont: '#4a4a4a',
   chartFont: '#c4c4c4',
   chartDay: '#3c3c46',
+  genderMan: '#629acd',
+  genderWoman: '#E79997',
 }
 
 export default theme


### PR DESCRIPTION
파이차트 레이아웃 및 select 레이아웃 구현
파이차트는 두개의 원을 그리고 남,여의 비율에 따라 색상이 영역을 차지하도록
background의 conic-gradient 속성을 활용해서 구현하였습니다.
연령차트의 색상example과 성별차트의 색상example이 동일한 레이아웃이라
하나의 컴포넌트로 구현하였습니다.